### PR TITLE
feat: create browser per-worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest": "^25.1.0",
     "jest-environment-node": "^25.1.0",
     "lint-staged": "^10.0.7",
-    "playwright": "^0.9.24",
+    "playwright": "^0.10.0",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.1"
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,3 @@
-import path from 'path'
-import os from 'os'
-
-export const DIR = path.join(os.tmpdir(), 'jest_playwright_global_setup')
-export const WS_ENDPOINT_PATH = path.join(DIR, 'wsEndpoint')
-
 export const CHROMIUM = 'chromium'
 export const FIREFOX = 'firefox'
 export const WEBKIT = 'webkit'

--- a/src/global.js
+++ b/src/global.js
@@ -1,24 +1,5 @@
-import fs from 'fs'
-// eslint-disable-next-line import/no-extraneous-dependencies
-import rimraf from 'rimraf'
-import playwright from 'playwright'
-import { DIR, WS_ENDPOINT_PATH } from './constants'
-import { checkBrowserEnv, readConfig, getBrowserType } from './utils'
-
-let browser
-
 export async function setup() {
-  const config = await readConfig()
-  const browserType = getBrowserType(config)
-  checkBrowserEnv(browserType)
-  const { launchBrowserApp } = config
-  browser = await playwright[browserType].launchBrowserApp(launchBrowserApp)
-  // Instead, we expose the connection details via file system to be used in tests
-  fs.mkdirSync(DIR, { recursive: true })
-  fs.writeFileSync(WS_ENDPOINT_PATH, browser.wsEndpoint())
 }
 
 export async function teardown() {
-  await browser.close()
-  rimraf.sync(DIR)
 }


### PR DESCRIPTION
This patch launches browser per-worker. This is generally
a workaround for WebKit lacking multi-client support: https://github.com/microsoft/playwright/issues/830

Fixes #5