### PR TITLE
Ability to support specific browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Running your tests using [Jest](https://github.com/facebook/jest) & [Playwright]
 npm install jest-playwright-preset playwright
 ```
 
+Also you can use `jest-playwright-preset` with specific playwright packages:
+`playwright-webkit`, `playwright-chromium` and `playwright-firefox`
+
+```
+npm install jest-playwright-preset playwright-firefox
+```
+
 ## Usage
 
 Update your Jest configuration:
@@ -47,6 +54,7 @@ You can specify a `jest-playwright.config.js` at the root of the project or defi
 ## Browser type
 
 You can specify browser in multiple ways:
+**Note**: You should do it only if you are using whole playwright package
 
 - With `BROWSER` environment variable
 - With your `jest-playwright.config.js`
@@ -56,7 +64,7 @@ If you don't pass any value it will be use `chromium` as default
 Use Playwright in your tests:
 
 ```json
-"test": "BROWSER=chromium jest"
+"test": "jest"
 ```
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-playwright-preset",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6524,18 +6524,18 @@
       }
     },
     "playwright": {
-      "version": "0.9.24",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-0.9.24.tgz",
-      "integrity": "sha512-CdSY4rcrzkNkLIBhbu2qlhMrQdVXZzdL/Ybufh+SB+OLutNBnfFiZsnOJ6vow2W0ik1MWM1fabqXNnyoQsVItg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-0.10.0.tgz",
+      "integrity": "sha512-f3VRME/PIO5NbcWnlCDfXwPC0DAZJ7ETkcAdE+sensLCOkfDtLh97E71ZuxNCaPYsUA6FIPi5syD8pHJW/4hQQ==",
       "dev": true,
       "requires": {
-        "playwright-core": "=0.9.24"
+        "playwright-core": "=0.10.0"
       }
     },
     "playwright-core": {
-      "version": "0.9.24",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.9.24.tgz",
-      "integrity": "sha512-4yxhmbk9wQGnhOsh8C6NLeQcez/uKzCgGAVwru47/1JrQV/MNyr+t4E+VBwGEcgnjzI9F33IaKsMuYDrqhBz4w==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.10.0.tgz",
+      "integrity": "sha512-yernA6yrrBhmb8M5eO6GZsJOrBKWOZszlu65Luz8LP7ryaDExN1sE9XjQBNbiwJ5Gfs8cehtAO7GfTDJt+Z2cQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,13 @@
     "*.js": "eslint --fix"
   },
   "peerDependencies": {
-    "jest-environment-node": "^25.1.0",
-    "playwright": "*"
+    "jest-environment-node": "^25.1.0"
+  },
+  "optionalDependencies": {
+    "playwright": "*",
+    "playwright-chromium": "*",
+    "playwright-firefox": "*",
+    "playwright-webkit": "*"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "format": "prettier --write \"*.{js,md}\" \"src/*.js\"",
     "lint": "eslint .",
     "prepublishOnly": "yarn run build",
-    "test": "jest"
+    "test:utils": "jest src/utils.test.js",
+    "test": "npm run test:utils && jest tests"
   },
   "husky": {
     "hooks": {

--- a/src/PlaywrightEnvironment.js
+++ b/src/PlaywrightEnvironment.js
@@ -63,11 +63,8 @@ class PlaywrightEnvironment extends NodeEnvironment {
     const config = await readConfig()
     const browserType = getBrowserType(config)
     checkBrowserEnv(browserType)
-    const { device, context, useStandaloneVersion } = config
-    const playwrightInstance = await getPlaywrightInstance(
-      browserType,
-      useStandaloneVersion,
-    )
+    const { device, context } = config
+    const playwrightInstance = await getPlaywrightInstance(browserType)
     let contextOptions = context
 
     const availableDevices = Object.keys(playwrightInstance.devices)

--- a/src/PlaywrightEnvironment.js
+++ b/src/PlaywrightEnvironment.js
@@ -36,16 +36,11 @@ function startBrowserCloseWatchdog() {
   }, 50)
 }
 
-async function getBrowserPerProcess() {
+async function getBrowserPerProcess(playwrightInstance, config) {
   if (!browserPerProcess) {
-    const config = await readConfig()
     const browserType = getBrowserType(config)
     checkBrowserEnv(browserType)
-    const { launchBrowserApp, useStandaloneVersion } = config
-    const playwrightInstance = getPlaywrightInstance(
-      browserType,
-      useStandaloneVersion,
-    )
+    const { launchBrowserApp } = config
     browserPerProcess = await playwrightInstance.launch(launchBrowserApp)
   }
   return browserPerProcess
@@ -69,7 +64,7 @@ class PlaywrightEnvironment extends NodeEnvironment {
     const browserType = getBrowserType(config)
     checkBrowserEnv(browserType)
     const { device, context, useStandaloneVersion } = config
-    const playwrightInstance = getPlaywrightInstance(
+    const playwrightInstance = await getPlaywrightInstance(
       browserType,
       useStandaloneVersion,
     )
@@ -86,7 +81,7 @@ class PlaywrightEnvironment extends NodeEnvironment {
         contextOptions = { ...contextOptions, viewport, userAgent }
       }
     }
-    this.global.browser = await getBrowserPerProcess()
+    this.global.browser = await getBrowserPerProcess(playwrightInstance, config)
     this.global.context = await this.global.browser.newContext(contextOptions)
     this.global.page = await this.global.context.newPage()
     this.global.page.on('pageerror', handleError)

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,10 +26,15 @@ export function getPlaywrightInstance(
   useStandaloneVersion = process.env.USE_STANDALONE_VERSION,
 ) {
   if (useStandaloneVersion) {
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    return require(`playwright-${browserType}`)
+    const playwrightPackage = `playwright-${browserType}`
+    try {
+      // eslint-disable-next-line global-require, import/no-dynamic-require
+      return require(playwrightPackage)
+    } catch (e) {
+      throw new Error(`You need to install ${playwrightPackage}`)
+    }
   }
-  // eslint-disable-next-line global-require
+  // eslint-disable-next-line global-require,import/no-extraneous-dependencies
   return require('playwright')[browserType]
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,6 +21,18 @@ export function getBrowserType(config) {
   return config.browser || CHROMIUM
 }
 
+export function getPlaywrightInstance(
+  browserType,
+  useStandaloneVersion = process.env.USE_STANDALONE_VERSION,
+) {
+  if (useStandaloneVersion) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    return require(`playwright-${browserType}`)
+  }
+  // eslint-disable-next-line global-require
+  return require('playwright')[browserType]
+}
+
 export async function readConfig() {
   const defaultConfig = DEFAULT_CONFIG
 

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,3 +1,5 @@
+import { checkBrowserEnv, readPackage } from './utils'
+
 const fs = require('fs')
 const path = require('path')
 const { readConfig, getBrowserType } = require('./utils')
@@ -78,5 +80,73 @@ describe('getBrowserType', () => {
     const config = await readConfig()
     const browserType = getBrowserType(config)
     expect(browserType).toBe(CHROMIUM)
+  })
+})
+
+describe('checkBrowserEnv', () => {
+  it('should throw Error with unknown type', async () => {
+    fs.exists.mockImplementationOnce((_, cb) => cb(true))
+    jest.mock(
+      path.join(__dirname, '..', 'jest-playwright.config.js'),
+      () => ({
+        browser: 'unknown',
+      }),
+      { virtual: true },
+    )
+    const config = await readConfig()
+    const browserType = getBrowserType(config)
+    expect(() => checkBrowserEnv(browserType)).toThrow()
+  })
+})
+
+describe('readPackage', () => {
+  it('should return null when dependencies does not passed', async () => {
+    fs.exists.mockImplementationOnce((_, cb) => cb(true))
+    jest.mock(
+      path.join(__dirname, '..', 'package.json'),
+      () => ({
+        dependencies: {},
+      }),
+      { virtual: true },
+    )
+    let error
+    try {
+      await readPackage()
+    } catch (e) {
+      error = e
+    }
+    expect(error).toEqual(
+      new Error('None of playwright packages was not found in dependencies'),
+    )
+  })
+  it('should return playwright when it is defined', async () => {
+    fs.exists.mockImplementationOnce((_, cb) => cb(true))
+    jest.mock(
+      path.join(__dirname, '..', 'package.json'),
+      () => ({
+        dependencies: {
+          playwright: '*',
+        },
+      }),
+      { virtual: true },
+    )
+
+    const playwright = await readPackage()
+    expect(playwright).toEqual('playwright')
+  })
+  it('should return playwright-firefox when it is defined', async () => {
+    fs.exists.mockImplementationOnce((_, cb) => cb(true))
+    jest.mock(
+      path.join(__dirname, '..', 'package.json'),
+      () => ({
+        devDependencies: {
+          'playwright-firefox': '*',
+        },
+      }),
+      { virtual: true },
+    )
+
+    const playwright = await readPackage()
+    expect(playwright).toEqual('playwright-firefox')
   })
 })


### PR DESCRIPTION
I just think about support this feature, but I haven't got any ideas about clean and simple API.

In this PR my thoughts about it. You can add come configuration to support specific version through `jest-playwright.config.js` :
```javascript
module.exports = {
    browser: 'firefox',
    useStandaloneVersion: true,
    ...
}
```

or with env params: `BROWSER=firefox USE_STANDALONE_VERSION=true jest` 

Also I should think about **peerDependencies**, should it be replaced with **optionalDependencies**?

#7 