### PR TITLE
feat: inherit from default config on objects

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -46,12 +46,12 @@ export async function readConfig() {
     ...defaultConfig,
     launchBrowserApp: {
       ...defaultConfig.launchBrowserApp,
-      ...(localConfig.launchBrowserApp || {})
+      ...(localConfig.launchBrowserApp || {}),
     },
     context: {
       ...defaultConfig.context,
-      ...(localConfig.context || {})
+      ...(localConfig.context || {}),
     },
-    ...localConfig
+    ...localConfig,
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,5 +42,16 @@ export async function readConfig() {
 
   // eslint-disable-next-line global-require,import/no-dynamic-require
   const localConfig = await require(absConfigPath)
-  return { ...defaultConfig, ...localConfig }
+  return {
+    ...defaultConfig,
+    launchBrowserApp: {
+      ...defaultConfig.launchBrowserApp,
+      ...(localConfig.launchBrowserApp || {})
+    },
+    context: {
+      ...defaultConfig.context,
+      ...(localConfig.context || {})
+    },
+    ...localConfig
+  }
 }


### PR DESCRIPTION
Currently we have to provide the `webSocket: true` value manually if we are using a custom `launchBrowserApp` setting.
With this change the `launchBrowserApp` and `config` option will inherit from the default config, so that we don't have to specify it.