### PR TITLE
Add ability to support device from env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-playwright-preset",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/PlaywrightEnvironment.js
+++ b/src/PlaywrightEnvironment.js
@@ -1,7 +1,9 @@
 import NodeEnvironment from 'jest-environment-node'
 import {
   checkBrowserEnv,
+  checkDeviceEnv,
   getBrowserType,
+  getDeviceType,
   getPlaywrightInstance,
   readConfig,
 } from './utils'
@@ -63,20 +65,16 @@ class PlaywrightEnvironment extends NodeEnvironment {
     const config = await readConfig()
     const browserType = getBrowserType(config)
     checkBrowserEnv(browserType)
-    const { device, context } = config
+    const { context } = config
+    const device = getDeviceType(config)
     const playwrightInstance = await getPlaywrightInstance(browserType)
     let contextOptions = context
 
     const availableDevices = Object.keys(playwrightInstance.devices)
     if (device) {
-      if (!availableDevices.includes(device)) {
-        throw new Error(
-          `Wrong device. Should be one of [${availableDevices}], but got ${device}`,
-        )
-      } else {
-        const { viewport, userAgent } = playwrightInstance.devices[device]
-        contextOptions = { ...contextOptions, viewport, userAgent }
-      }
+      checkDeviceEnv(device, availableDevices)
+      const { viewport, userAgent } = playwrightInstance.devices[device]
+      contextOptions = { ...contextOptions, viewport, userAgent }
     }
     this.global.browser = await getBrowserPerProcess(playwrightInstance, config)
     this.global.context = await this.global.browser.newContext(contextOptions)

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,6 +22,22 @@ export function checkBrowserEnv(param) {
   }
 }
 
+export function checkDeviceEnv(device, availableDevices) {
+  if (!availableDevices.includes(device)) {
+    throw new Error(
+      `Wrong device. Should be one of [${availableDevices}], but got ${device}`,
+    )
+  }
+}
+
+export function getDeviceType(config) {
+  const processDevice = process.env.DEVICE
+  if (processDevice) {
+    return processDevice
+  }
+  return config.device
+}
+
 export function getBrowserType(config) {
   const processBrowser = process.env.BROWSER
   if (processBrowser) {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,8 +1,13 @@
-import { checkBrowserEnv, readPackage } from './utils'
-
 const fs = require('fs')
 const path = require('path')
-const { readConfig, getBrowserType } = require('./utils')
+const {
+  readConfig,
+  getBrowserType,
+  getDeviceType,
+  checkBrowserEnv,
+  checkDeviceEnv,
+  readPackage,
+} = require('./utils')
 const { DEFAULT_CONFIG, CHROMIUM } = require('./constants')
 
 jest.spyOn(fs, 'exists')
@@ -100,6 +105,20 @@ describe('getBrowserType', () => {
   })
 })
 
+describe('getDeviceType', () => {
+  it('should return "undefined" when there is no device', async () => {
+    const config = await readConfig()
+    const device = getDeviceType(config)
+    expect(device).toBe(undefined)
+  })
+  it('should return BROWSER if defined', async () => {
+    process.env.DEVICE = 'iPhone 11'
+    const device = getDeviceType()
+    expect(device).toBe(process.env.DEVICE)
+    delete process.env.DEVICE
+  })
+})
+
 describe('checkBrowserEnv', () => {
   it('should throw Error with unknown type', async () => {
     fs.exists.mockImplementationOnce((_, cb) => cb(true))
@@ -113,6 +132,14 @@ describe('checkBrowserEnv', () => {
     const config = await readConfig()
     const browserType = getBrowserType(config)
     expect(() => checkBrowserEnv(browserType)).toThrow()
+  })
+})
+
+describe('checkDeviceEnv', () => {
+  it('should throw Error with unknown type', async () => {
+    const device = 'unknown'
+    const devices = ['iPhone 11', 'Pixel 2', 'Nexus 4']
+    expect(() => checkDeviceEnv(device, devices)).toThrow()
   })
 })
 


### PR DESCRIPTION
Add ability to set device with env variable, like so:
```
BROWSER=chromium DEVICE='Nexus 4' jest
```

This is the step to support running tests for multiple devices:
https://github.com/mmarkelov/jest-playwright/issues/19