### PR TITLE
Ability to specify custom device

### DIFF
--- a/src/PlaywrightEnvironment.js
+++ b/src/PlaywrightEnvironment.js
@@ -72,9 +72,14 @@ class PlaywrightEnvironment extends NodeEnvironment {
 
     const availableDevices = Object.keys(playwrightInstance.devices)
     if (device) {
-      checkDeviceEnv(device, availableDevices)
-      const { viewport, userAgent } = playwrightInstance.devices[device]
-      contextOptions = { ...contextOptions, viewport, userAgent }
+      if (typeof device === 'object') {
+        const { viewport, userAgent } = device
+        contextOptions = { ...contextOptions, viewport, userAgent }
+      } else {
+        checkDeviceEnv(device, availableDevices)
+        const { viewport, userAgent } = playwrightInstance.devices[device]
+        contextOptions = { ...contextOptions, viewport, userAgent }
+      }
     }
     this.global.browser = await getBrowserPerProcess(playwrightInstance, config)
     this.global.context = await this.global.browser.newContext(contextOptions)

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,7 +33,11 @@ export function checkDeviceEnv(device, availableDevices) {
 export function getDeviceType(config) {
   const processDevice = process.env.DEVICE
   if (processDevice) {
-    return processDevice
+    try {
+      return JSON.parse(processDevice)
+    } catch (e) {
+      return processDevice
+    }
   }
   return config.device
 }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -124,7 +124,7 @@ describe('getDeviceType', () => {
     // module.exports = {
     //   device: {
     //     name: "Apple MacBook Pro 13-inch (Retina display)",
-    //     viewPort: {
+    //     viewport: {
     //       width: 1280,
     //       height: 800,
     //       deviceScaleFactor: 2,
@@ -136,7 +136,7 @@ describe('getDeviceType', () => {
   it('should return an object if a custom viewport in BROWSER is defined', async () => {
     const deviceJSON = {
       name: 'Apple MacBook Pro 13-inch (Retina display)',
-      viewPort: {
+      viewport: {
         width: 1280,
         height: 800,
         deviceScaleFactor: 2,

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -117,6 +117,37 @@ describe('getDeviceType', () => {
     expect(device).toBe(process.env.DEVICE)
     delete process.env.DEVICE
   })
+  it('should return an object if a custom viewport is defined', async () => {
+    // TODO: How to test this?
+    // use case, where one can define a custom device, just like with raw playwright:
+    // in jest-playwright.config.js
+    // module.exports = {
+    //   device: {
+    //     name: "Apple MacBook Pro 13-inch (Retina display)",
+    //     viewPort: {
+    //       width: 1280,
+    //       height: 800,
+    //       deviceScaleFactor: 2,
+    //       isMobile: false,
+    //     }
+    //   },
+    // }
+  })
+  it('should return an object if a custom viewport in BROWSER is defined', async () => {
+    const deviceJSON = {
+      name: 'Apple MacBook Pro 13-inch (Retina display)',
+      viewPort: {
+        width: 1280,
+        height: 800,
+        deviceScaleFactor: 2,
+        isMobile: false,
+      },
+    }
+    process.env.DEVICE = JSON.stringify(deviceJSON)
+    const device = getDeviceType()
+    expect(device).toStrictEqual(deviceJSON)
+    delete process.env.DEVICE
+  })
 })
 
 describe('checkBrowserEnv', () => {


### PR DESCRIPTION
I would like to be able to specify a custom device. I'm not sure if this is a good idea, and if it is, if what I did here is the right way to do it. Tell me what you think.

Also, how do I test the `jest-playwright.config.js`? I could only test the ~~BROWSER~~ DEVICE environment variable (see diff patch).

What I'm currently doing is I have a dummy project, let's say `jest-playwright-test`, and then I manually `npm i -D ../jest-playwright` my local forked repo. I'm sure there are more efficient ways to test, but I don't know what they are yet.