### PR TITLE
Add ability to config selectors

### DIFF
--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -82,9 +82,12 @@ class PlaywrightEnvironment extends NodeEnvironment {
     const config = await readConfig()
     const browserType = getBrowserType(config)
     checkBrowserEnv(browserType)
-    const { context, server } = config
+    const { context, server, selectors } = config
     const device = getDeviceType(config)
-    const playwrightInstance = await getPlaywrightInstance(browserType)
+    const playwrightInstance = await getPlaywrightInstance(
+      browserType,
+      selectors,
+    )
     let contextOptions = context
 
     if (server) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,7 @@ export const WEBKIT = 'webkit'
 export type BrowserType = typeof CHROMIUM | typeof FIREFOX | typeof WEBKIT
 
 export type SelectorType = {
-  engine: () => void
+  script: string | Function | { path?: string; content?: string }
   name: string
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,11 @@ export const WEBKIT = 'webkit'
 
 export type BrowserType = typeof CHROMIUM | typeof FIREFOX | typeof WEBKIT
 
+export type SelectorType = {
+  engine: () => void
+  name: string
+}
+
 export type PlaywrightRequireType =
   | BrowserType
   | typeof PLAYWRIGHT
@@ -27,6 +32,7 @@ export interface Config {
   device?: string
   devices?: string[]
   server?: JestDevServerOptions
+  selectors?: SelectorType[]
 }
 
 export const DEFAULT_CONFIG: Config = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import {
   FIREFOX,
   PLAYWRIGHT,
   PlaywrightRequireType,
+  SelectorType,
   WEBKIT,
 } from './constants'
 import { BrowserType as PlayWrightBrowserType } from 'playwright'
@@ -82,10 +83,20 @@ export const readPackage = async (): Promise<PlaywrightRequireType> => {
 
 export const getPlaywrightInstance = async (
   browserType: BrowserType,
+  selectors?: SelectorType[],
 ): Promise<PlayWrightBrowserType> => {
   const playwrightPackage = await readPackage()
   if (playwrightPackage === PLAYWRIGHT) {
-    return require('playwright')[browserType]
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const playwright = require('playwright')
+    if (selectors) {
+      await Promise.all(
+        selectors.map(({ engine, name }) =>
+          playwright.selectors.register(engine, { name }),
+        ),
+      )
+    }
+    return playwright[browserType]
   }
   if (playwrightPackage === CORE) {
     const browser = require(`playwright-${CORE}`)[browserType]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,8 +91,8 @@ export const getPlaywrightInstance = async (
     const playwright = require('playwright')
     if (selectors) {
       await Promise.all(
-        selectors.map(({ engine, name }) =>
-          playwright.selectors.register(engine, { name }),
+        selectors.map(({ script, name }) =>
+          playwright.selectors.register(script, { name }),
         ),
       )
     }


### PR DESCRIPTION
#60 
I decided that move something to **global**  isn't really good solution. So I decide to move this logic inside. So you can config selectors with `jest-playwright.config.js`:
```js
const {
    selectorEngine,
} = require('query-selector-shadow-dom/plugins/playwright');

module.exports = {
    selectors: [
        {engine: selectorEngine, name: 'shadow'}
    ],
    ...
}
```

You can specify it with array of object with **engine** and **name**. So **jest-playwright** will iterate through it and will register whole array