### PR TITLE
Fixes to check browsers

### DIFF
--- a/src/bin/testProcess.ts
+++ b/src/bin/testProcess.ts
@@ -60,11 +60,14 @@ const exec = ({
 
 const runner = async (sequence: string, params: string[]): Promise<void> => {
   // TODO Work only if we pass config through package.json
-  const rootDir = process.env.npm_package_jest_rootDir
-    ? `${process.cwd()}/${process.env.npm_package_jest_rootDir}/`
-    : process.cwd()
+  const rootDir = `${process.cwd()}/${process.env.npm_package_jest_rootDir ||
+    ''}/`
   const config = await readConfig(rootDir)
-  const { browsers = [], devices = [] } = config
+  const { devices = [] } = config
+  let browsers = config.browsers
+  if (!browsers) {
+    browsers = browser ? [browser] : []
+  }
   let exitCodes: (number | null)[] = []
   checkCommand(browsers, devices)
   if (!browsers.length && devices.length) {

--- a/src/bin/testProcess.ts
+++ b/src/bin/testProcess.ts
@@ -63,7 +63,7 @@ const runner = async (sequence: string, params: string[]): Promise<void> => {
   const rootDir = `${process.cwd()}/${process.env.npm_package_jest_rootDir ||
     ''}/`
   const config = await readConfig(rootDir)
-  const { devices = [] } = config
+  const { devices = [], browser } = config
   let browsers = config.browsers
   if (!browsers) {
     browsers = browser ? [browser] : []

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,4 +1,5 @@
-import { Page, Browser, BrowserContext } from 'playwright-core'
+import { Page, BrowserContext } from 'playwright-core'
+import { BrowserType } from '../src/constants'
 
 interface JestPlaywright {
   /**
@@ -17,7 +18,7 @@ interface JestPlaywright {
 
 declare global {
   const page: Page
-  const browser: Browser
+  const browser: BrowserType
   const context: BrowserContext
   const jestPlaywright: JestPlaywright
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,5 +1,4 @@
-import { Page, BrowserContext } from 'playwright-core'
-import { BrowserType } from '../src/constants'
+import { Page, Browser, BrowserContext } from 'playwright-core'
 
 interface JestPlaywright {
   /**
@@ -18,7 +17,7 @@ interface JestPlaywright {
 
 declare global {
   const page: Page
-  const browser: BrowserType
+  const browser: Browser
   const context: BrowserContext
   const jestPlaywright: JestPlaywright
 }


### PR DESCRIPTION
Actually I didn't know the best way for this case. May be we should warn user that he try to run tests in parallel for only one. For now I just decided to run tests for only one browser, but I'm not sure that is right approach 