### PR TITLE
fix(setup): Refactor playwright devices based on latest API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5205,12 +5205,55 @@
       }
     },
     "playwright": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-0.11.1.tgz",
-      "integrity": "sha512-Sx/WCb88u6Q73klQKGjGY2PJSbUl7JAHIie3mFGTpXPPo79cmMzVJl2e07v/qO3VGFd13bF4z8vMt2UVPc/ygQ==",
+      "version": "0.11.1-next.1584655833455",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-0.11.1-next.1584655833455.tgz",
+      "integrity": "sha512-HnOgLw14z7PRQCC3xmeET3z3c3qf++EMcOKAxpLwFooMY3bIRmiIpBcymvsMmT77H9oaI/mmXb+OIlUUMF+ndw==",
       "dev": true,
       "requires": {
-        "playwright-core": "=0.11.1"
+        "playwright-core": "=0.11.1-next.1584655833455"
+      },
+      "dependencies": {
+        "playwright-core": {
+          "version": "0.11.1-next.1584655833455",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.11.1-next.1584655833455.tgz",
+          "integrity": "sha512-YLSRByo2uwTLW0KwCrGhAAn6Geyg9q0wUTHHqWYDpSw4qMLJQB7eNuBNOqJtStu/5igLwil11UW36tvc6A6V6w==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "extract-zip": "^1.6.6",
+            "https-proxy-agent": "^3.0.0",
+            "jpeg-js": "^0.3.6",
+            "pngjs": "^3.4.0",
+            "progress": "^2.0.3",
+            "proxy-from-env": "^1.1.0",
+            "rimraf": "^3.0.2",
+            "ws": "^6.1.0"
+          }
+        },
+        "proxy-from-env": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "playwright-chromium": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "jest": "^25.1.0",
     "jest-environment-node": "^25.1.0",
     "lint-staged": "^10.0.7",
-    "playwright": ">=0.11.1",
+    "playwright": "^0.11.1-next.1584655833455",
     "playwright-chromium": ">=0.11.0",
     "playwright-core": ">=0.11.0",
     "playwright-firefox": ">=0.11.0",

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -7,6 +7,7 @@ import {
   getBrowserType,
   getDeviceType,
   getPlaywrightInstance,
+  getPlaywrightDevices,
   readConfig,
 } from './utils'
 import { Config, CHROMIUM } from './constants'
@@ -119,10 +120,10 @@ class PlaywrightEnvironment extends NodeEnvironment {
       }
     }
 
-    const availableDevices = Object.keys(playwrightInstance.devices)
+    const availableDevices = getPlaywrightDevices()
     if (device) {
-      checkDeviceEnv(device, availableDevices)
-      const { viewport, userAgent } = playwrightInstance.devices[device]
+      checkDeviceEnv(device, Object.keys(availableDevices))
+      const { viewport, userAgent } = availableDevices[device]
       contextOptions = { viewport, userAgent, ...contextOptions }
     }
     this.global.browser = await getBrowserPerProcess(playwrightInstance, config)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,7 @@ import {
   WEBKIT,
 } from './constants'
 import { BrowserType as PlayWrightBrowserType } from 'playwright'
+import { Devices } from 'playwright-core/lib/types'
 
 const exists = promisify(fs.exists)
 
@@ -104,6 +105,10 @@ export const getPlaywrightInstance = async (
     return browser
   }
   return require(`playwright-${playwrightPackage}`)[playwrightPackage]
+}
+
+export const getPlaywrightDevices = (): Devices => {
+  return require('playwright').devices
 }
 
 export const readConfig = async (


### PR DESCRIPTION
I decided to install `playwright@next` and `jest-playwright-preset@latest` in my current project. I encountered an issue where null is being passed to Object.keys in setup.

I decided to do a little digging and found that playwright[browserType].devices is no longer valid, so I implemented a temporary manual fix:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/57334943/77140073-52db1080-6ab3-11ea-867e-60d079eea9e9.png">

Per commit https://github.com/microsoft/playwright/commit/9aa56a6b9e8f08886f781def9034355e2cffedf0, playwright[browserType].devices
has been removed.

Anyway, this is just a heads up.